### PR TITLE
Fix syntax error

### DIFF
--- a/syntaxes/blueprint.tmGrammar.json
+++ b/syntaxes/blueprint.tmGrammar.json
@@ -342,7 +342,9 @@
             },
             "end": "\\]",
             "endCaptures": {
-                "0": "punctuation.section.qualifier.end.blueprint-gtk"
+                "0": {
+                    "name": "punctuation.section.qualifier.end.blueprint-gtk"
+                }
             },
             "patterns": [
                 {


### PR DESCRIPTION
* `'Repository[qualifier].EndCaptures[0]' expected a map, got 'string'`

This prevented me from [adding the syntax highlighting to GitHub](https://github.com/github-linguist/linguist) and being able to use it in SublimeText.
